### PR TITLE
Add Create Table to grammar and typechecker

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -74,11 +74,18 @@ pub struct Insert {
 }
 
 #[derive(Debug)]
+pub struct CreateTable {
+    pub table: String,
+    pub columns: Vec<String>,
+}
+
+#[derive(Debug)]
 pub enum Stmt {
     Select(Select),
     Insert(Insert),
     Delete(Delete),
     Update(Update),
+    CreateTable(CreateTable),
     CreateType(CreateType),
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -134,7 +134,8 @@ fn ast_grammar() {
         r#"INSERT INTO table VALUES (T::Val1(1, 2, Val2()), true);"#,
         r#"SELECT x: Val1(1, InnerVal2(true, _), y) FROM t WHERE true;"#,
         r#"CREATE TYPE newCoolType AS VARIANT {};"#,
-        r#"CREATE TABLE bananas;",
+        r#"CREATE TABLE bananas ();"#,
+        r#"CREATE TABLE bananas (INT, TEXT);"#,
         r#"CREATE TYPE newCoolType AS VARIANT {
             Var1(),
             Var1(Bool),
@@ -152,6 +153,7 @@ fn ast_grammar() {
         r#"DELETE just;"#,
         r#"DELETE FROM just WHERE ;"#,
         r#"DELETE FROM just some more tables ;"#,
+        r#"CREATE TABLE bananas;"#,
         r#"DELETE FROM now, with, commas ;"#,
         r#"UPDATE SET xxsxsxsxsxsxsxs=2 ;"#,
     ];

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -134,6 +134,7 @@ fn ast_grammar() {
         r#"INSERT INTO table VALUES (T::Val1(1, 2, Val2()), true);"#,
         r#"SELECT x: Val1(1, InnerVal2(true, _), y) FROM t WHERE true;"#,
         r#"CREATE TYPE newCoolType AS VARIANT {};"#,
+        r#"CREATE TABLE bananas;",
         r#"CREATE TYPE newCoolType AS VARIANT {
             Var1(),
             Var1(Bool),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -130,7 +130,7 @@ WhereClause: WhereClause = {
 CreateTable: CreateTable = {
     CREATE TABLE <table:Ident>
         <columns:("(" Comma<Ident> ")")?>
-    => CreateType {
+    => CreateTable {
         table,
         columns: columns.map(|(_, cols, _)| cols).unwrap_or(vec![]),
     }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -28,6 +28,7 @@ match {
     "AND" => AND,
     "OR" => OR,
     "CREATE" => CREATE,
+    "TABLE" => TABLE,
     "TYPE" => TYPE,
     "AS" => AS,
     "VARIANT" => VARIANT,
@@ -61,6 +62,7 @@ pub Stmt: Stmt = {
     <Select> ";" => Stmt::Select(<>),
     <Insert> ";" => Stmt::Insert(<>),
     <Delete> ";" => Stmt::Delete(<>),
+    <CreateTable> ";" => Stmt::CreateTable(<>),
     <Update> ";" => Stmt::Update(<>),
     <CreateType> ";" => Stmt::CreateType(<>),
 }
@@ -123,6 +125,15 @@ SelectFrom2: SelectFrom = {
 
 WhereClause: WhereClause = {
     WHERE <Expr> => WhereClause(<>),
+}
+
+CreateTable: CreateTable = {
+    CREATE TABLE <table:Ident>
+        <columns:("(" Comma<Ident> ")")?>
+    => CreateType {
+        table,
+        columns: columns.map(|(_, cols, _)| cols).unwrap_or(vec![]),
+    }
 }
 
 Insert: Insert = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -129,20 +129,20 @@ WhereClause: WhereClause = {
 
 CreateTable: CreateTable = {
     CREATE TABLE <table:Ident>
-        <columns:("(" Comma<Ident> ")")?>
+        <columns:("(" <Comma<Ident>> ")")>
     => CreateTable {
         table,
-        columns: columns.map(|(_, cols, _)| cols).unwrap_or(vec![]),
+        columns,
     }
 }
 
 Insert: Insert = {
     INSERT INTO <table:Ident>
-        <columns:("(" Comma<Ident> ")")?>
+        <columns:("(" <Comma<Ident>> ")")?>
         <values:InsertValues?>
     => Insert {
         table,
-        columns: columns.map(|(_, cols, _)| cols).unwrap_or(vec![]),
+        columns: columns.unwrap_or(vec![]),
         values: values.unwrap_or(vec![]),
     }
 }

--- a/src/pre_typechecker.rs
+++ b/src/pre_typechecker.rs
@@ -17,6 +17,7 @@ pub fn get_table_permissions(stmt: &Stmt) -> Vec<TableRequest> {
             rw: RW::Write,
         }],
         Stmt::CreateType(_) => vec![],
+        Stmt::CreateTable(_)=> vec![],
     }
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -77,8 +77,8 @@ pub fn check_stmt(stmt: &Stmt, globals: &ResourcesGuard<'_>) -> Result<(), TypeE
         Stmt::Update(update) => check_update(update, &mut ctx),
         Stmt::Delete(delete) => check_delete(delete, &mut ctx),
         Stmt::Insert(_insert) => unimplemented!("Stmt::Insert"),
-        Stmt::CreateTable(createtable) => unimplemented!("Stmt::CreateTable"),
-        Stmt::CreateType(create) => check_create_type(create, &mut ctx),
+        Stmt::CreateTable(_create_table) => unimplemented!("Stmt::CreateTable"),
+        Stmt::CreateType(create_type) => check_create_type(create_type, &mut ctx),
     }
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -77,6 +77,7 @@ pub fn check_stmt(stmt: &Stmt, globals: &ResourcesGuard<'_>) -> Result<(), TypeE
         Stmt::Update(update) => check_update(update, &mut ctx),
         Stmt::Delete(delete) => check_delete(delete, &mut ctx),
         Stmt::Insert(_insert) => unimplemented!("Stmt::Insert"),
+        Stmt::CreateTable(createtable) => unimplemented!("Stmt::CreateTable"),
         Stmt::CreateType(create) => check_create_type(create, &mut ctx),
     }
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -190,6 +190,16 @@ fn check_update(update: &Update, ctx: &mut Context) -> Result<(), TypeError> {
     Ok(())
 }
 
+fn check_create_table(create_table: &CreateTable, ctx: &mut Context) -> Result<(), TypeError> {
+    for column in &create_table.columns {
+        if ctx.globals.types.get(column).is_none() {
+            return Err(TypeError::Undefined(column.clone()));
+        }
+    }
+
+    Ok(())
+}
+
 fn check_create_type(create: &CreateType, ctx: &mut Context) -> Result<(), TypeError> {
     // For a type:
     // MyVariant = Var1 TypeA | Var2 TypeB TypeC

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -77,7 +77,7 @@ pub fn check_stmt(stmt: &Stmt, globals: &ResourcesGuard<'_>) -> Result<(), TypeE
         Stmt::Update(update) => check_update(update, &mut ctx),
         Stmt::Delete(delete) => check_delete(delete, &mut ctx),
         Stmt::Insert(_insert) => unimplemented!("Stmt::Insert"),
-        Stmt::CreateTable(_create_table) => unimplemented!("Stmt::CreateTable"),
+        Stmt::CreateTable(create_table) => check_create_table(create_table, &mut ctx),
         Stmt::CreateType(create_type) => check_create_type(create_type, &mut ctx),
     }
 }


### PR DESCRIPTION
This PR adds create table to the grammar which allows us to create tables for the DB. It also adds a typecheck so the types of the columns in the table is of an existing type.

@hulthe @Sorchar @Arunvik contributed to this.