### PR TITLE
Implement a full slice of database

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -76,7 +76,7 @@ pub struct Insert {
 #[derive(Debug)]
 pub struct CreateTable {
     pub table: String,
-    pub columns: Vec<String>,
+    pub columns: Vec<(String, String)>,
 }
 
 #[derive(Debug)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -135,7 +135,7 @@ fn ast_grammar() {
         r#"SELECT x: Val1(1, InnerVal2(true, _), y) FROM t WHERE true;"#,
         r#"CREATE TYPE newCoolType AS VARIANT {};"#,
         r#"CREATE TABLE bananas ();"#,
-        r#"CREATE TABLE bananas (INT, TEXT);"#,
+        r#"CREATE TABLE bananas (col_a Integer, col_b Double);"#,
         r#"CREATE TYPE newCoolType AS VARIANT {
             Var1(),
             Var1(Bool),
@@ -154,6 +154,7 @@ fn ast_grammar() {
         r#"DELETE FROM just WHERE ;"#,
         r#"DELETE FROM just some more tables ;"#,
         r#"CREATE TABLE bananas;"#,
+        r#"CREATE TABLE bananas (without_type);"#,
         r#"DELETE FROM now, with, commas ;"#,
         r#"UPDATE SET xxsxsxsxsxsxsxs=2 ;"#,
     ];

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,10 +1,23 @@
 use crate::ast::*;
 use crate::global::{send_request, ResourcesGuard, Request, Response};
 use crate::table::{Table, Schema};
+use crate::types::Value;
+
+
+struct Context {
+    // TODO
+}
+
+impl Context {
+    pub fn empty() -> Context {
+        Context {}
+    }
+}
 
 pub fn execute_query(ast: Stmt, resources: ResourcesGuard) -> String {
     match ast {
         Stmt::CreateTable(create_table) => execute_create_table(create_table, resources),
+        Stmt::Insert(insert) => execute_insert(insert, resources),
         _ => unimplemented!("Not implemented: {:?}", ast),
     }
 }
@@ -28,4 +41,28 @@ fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard) ->
         Response::TableAlreadyExists => "Table already exists\n",
         _ => unreachable!(),
     }.to_string()
+}
+
+fn execute_insert(insert: Insert, mut resources: ResourcesGuard) -> String {
+
+    let (table, types) = resources.write_table(&insert.table);
+
+    let ctx = Context::empty();
+
+    let values: Vec<_> = insert.values
+        .into_iter()
+        .map(|expr| execute_expr(expr, &ctx))
+        .collect();
+
+    table.push_row(&values, &types);
+
+    //"Row inserted".to_string()
+    format!("{:#?}", table)
+}
+
+fn execute_expr(expr: Expr, _ctx: &Context) -> Value {
+    match expr {
+        Expr::Value(v) => v,
+        _ => unimplemented!("Non-value exprs"),
+    }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,8 +1,7 @@
 use crate::ast::*;
-use crate::global::{send_request, ResourcesGuard, Request, Response};
-use crate::table::{Table, Schema};
+use crate::global::{send_request, Request, ResourcesGuard, Response};
+use crate::table::{Schema, Table};
 use crate::types::{Type, TypeId, Value};
-
 
 struct Context {
     // TODO
@@ -24,10 +23,14 @@ pub fn execute_query(ast: Stmt, resources: ResourcesGuard) -> String {
 }
 
 fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard) -> String {
-    let columns: Vec<_> = create_table.columns
+    let columns: Vec<_> = create_table
+        .columns
         .into_iter()
         .map(|(column_name, column_type)| {
-            let t_id = resources.type_map.get_id(&column_type).expect("Type does not exists");
+            let t_id = resources
+                .type_map
+                .get_id(&column_type)
+                .expect("Type does not exists");
             (column_name, t_id)
         })
         .collect();
@@ -41,7 +44,8 @@ fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard) ->
         Response::TableCreated => "Table created\n",
         Response::TableAlreadyExists => "Table already exists\n",
         _ => unreachable!(),
-    }.to_string()
+    }
+    .to_string()
 }
 
 fn execute_create_type(create_type: CreateType, mut resources: ResourcesGuard) -> String {
@@ -51,9 +55,11 @@ fn execute_create_type(create_type: CreateType, mut resources: ResourcesGuard) -
 
     match create_type {
         CreateType::Variant(name, variants) => {
-            let variant_types: Vec<_> = variants.into_iter()
+            let variant_types: Vec<_> = variants
+                .into_iter()
                 .map(|(constructor, subtypes)| {
-                    let subtype_ids: Vec<TypeId> = subtypes.iter()
+                    let subtype_ids: Vec<TypeId> = subtypes
+                        .iter()
                         .map(|type_name| types.get_id(type_name).unwrap())
                         .collect();
 
@@ -76,12 +82,12 @@ fn execute_create_type(create_type: CreateType, mut resources: ResourcesGuard) -
 }
 
 fn execute_insert(insert: Insert, mut resources: ResourcesGuard) -> String {
-
     let (table, types) = resources.write_table(&insert.table);
 
     let ctx = Context::empty();
 
-    let values: Vec<_> = insert.values
+    let values: Vec<_> = insert
+        .values
         .into_iter()
         .map(|expr| execute_expr(expr, &ctx))
         .collect();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,31 @@
+use crate::ast::*;
+use crate::global::{send_request, ResourcesGuard, Request, Response};
+use crate::table::{Table, Schema};
+
+pub fn execute_query(ast: Stmt, resources: ResourcesGuard) -> String {
+    match ast {
+        Stmt::CreateTable(create_table) => execute_create_table(create_table, resources),
+        _ => unimplemented!("Not implemented: {:?}", ast),
+    }
+}
+
+fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard) -> String {
+    let columns: Vec<_> = create_table.columns
+        .into_iter()
+        .map(|(column_name, column_type)| {
+            let t_id = resources.types.get_id(&column_type).expect("Type does not exists");
+            (column_name, t_id)
+        })
+        .collect();
+
+    let schema = Schema::new(columns);
+    let table = Table::new(schema, &resources.types);
+
+    let request = Request::CreateTable(create_table.table, table);
+
+    match send_request(request) {
+        Response::TableCreated => "Table created\n",
+        Response::TableAlreadyExists => "Table already exists\n",
+        _ => unreachable!(),
+    }.to_string()
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,7 +1,7 @@
 use crate::ast::*;
 use crate::global::{send_request, ResourcesGuard, Request, Response};
 use crate::table::{Table, Schema};
-use crate::types::Value;
+use crate::types::{Type, TypeId, Value};
 
 
 struct Context {
@@ -17,6 +17,7 @@ impl Context {
 pub fn execute_query(ast: Stmt, resources: ResourcesGuard) -> String {
     match ast {
         Stmt::CreateTable(create_table) => execute_create_table(create_table, resources),
+        Stmt::CreateType(create_type) => execute_create_type(create_type, resources),
         Stmt::Insert(insert) => execute_insert(insert, resources),
         _ => unimplemented!("Not implemented: {:?}", ast),
     }
@@ -26,13 +27,13 @@ fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard) ->
     let columns: Vec<_> = create_table.columns
         .into_iter()
         .map(|(column_name, column_type)| {
-            let t_id = resources.types.get_id(&column_type).expect("Type does not exists");
+            let t_id = resources.type_map.get_id(&column_type).expect("Type does not exists");
             (column_name, t_id)
         })
         .collect();
 
     let schema = Schema::new(columns);
-    let table = Table::new(schema, &resources.types);
+    let table = Table::new(schema, &resources.type_map);
 
     let request = Request::CreateTable(create_table.table, table);
 
@@ -41,6 +42,37 @@ fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard) ->
         Response::TableAlreadyExists => "Table already exists\n",
         _ => unreachable!(),
     }.to_string()
+}
+
+fn execute_create_type(create_type: CreateType, mut resources: ResourcesGuard) -> String {
+    let types = &mut resources.type_map;
+
+    let mut output;
+
+    match create_type {
+        CreateType::Variant(name, variants) => {
+            let variant_types: Vec<_> = variants.into_iter()
+                .map(|(constructor, subtypes)| {
+                    let subtype_ids: Vec<TypeId> = subtypes.iter()
+                        .map(|type_name| types.get_id(type_name).unwrap())
+                        .collect();
+
+                    (constructor, subtype_ids)
+                })
+                .collect();
+
+            output = format!("Type {} created.\n", name);
+            types.insert(name, Type::Sum(variant_types));
+        }
+    }
+
+    output.push_str("Current types:\n");
+    for name in types.identifiers().keys() {
+        output.push_str("  ");
+        output.push_str(name);
+        output.push_str("\n");
+    }
+    output
 }
 
 fn execute_insert(insert: Insert, mut resources: ResourcesGuard) -> String {

--- a/src/global/manager.rs
+++ b/src/global/manager.rs
@@ -29,7 +29,10 @@ fn resource_manager(requests: Receiver<(Request, Sender<Response>)>) -> Result<!
         let (request, response_ch) = requests.recv().map_err(|e| e.to_string())?;
 
         match request {
-            Request::AcquireResources{ table_reqs, type_map_perms } => {
+            Request::AcquireResources {
+                table_reqs,
+                type_map_perms,
+            } => {
                 let type_map = type_map.clone();
                 let resources: Result<Vec<_>, _> = table_reqs
                     .into_iter()
@@ -44,9 +47,11 @@ fn resource_manager(requests: Receiver<(Request, Sender<Response>)>) -> Result<!
                     .collect();
 
                 match resources {
-                    Ok(tables) => {
-                        response_ch.send(Response::AcquiredResources(Resources::new(type_map, type_map_perms, tables)))
-                    }
+                    Ok(tables) => response_ch.send(Response::AcquiredResources(Resources::new(
+                        type_map,
+                        type_map_perms,
+                        tables,
+                    ))),
                     Err(response) => response_ch.send(response),
                 }
                 .map_err(|e| e.to_string())?;

--- a/src/global/tests.rs
+++ b/src/global/tests.rs
@@ -30,7 +30,7 @@ fn global_resources_contention() {
                 let mut rng = rand::thread_rng();
 
                 for _ in 0..10000 {
-                    let request: Vec<_> = table_ids
+                    let table_reqs: Vec<_> = table_ids
                         .iter()
                         .filter_map(|table_id| {
                             let i: usize = rng.gen();
@@ -51,13 +51,16 @@ fn global_resources_contention() {
                         .collect();
                     //eprintln!("{} {} {} {:?}", "==".color(Color::Red), thread, "requesting".color(Color::Red), request);
 
-                    let request_len = request.len();
+                    let table_count = table_reqs.len();
 
-                    let response = send_request(Request::AcquireResources(request));
+                    let response = send_request(Request::AcquireResources {
+                        table_reqs,
+                        type_map_perms: RW::Read,
+                    });
                     match response {
                         Response::AcquiredResources(mut resources) => {
                             let guard = resources.take();
-                            assert_eq!(guard.tables.len(), request_len);
+                            assert_eq!(guard.tables.len(), table_count);
                             drop(guard)
                             // TODO: verity correct tables
                         }

--- a/src/global/types.rs
+++ b/src/global/types.rs
@@ -76,9 +76,9 @@ impl Resources {
 
         ResourcesGuard {
             type_map: match self.type_map_perms {
-                    RW::Read => Resource::Read(self.type_map.read().expect(pmsg)),
-                    RW::Write => Resource::Write(self.type_map.write().expect(pmsg)),
-                },
+                RW::Read => Resource::Read(self.type_map.read().expect(pmsg)),
+                RW::Write => Resource::Write(self.type_map.write().expect(pmsg)),
+            },
             tables: self
                 .tables
                 .iter()
@@ -129,7 +129,8 @@ impl<'a> ResourcesGuard<'a> {
     }
 
     pub fn write_table(&mut self, name: &str) -> (&mut Table, &Resource<'a, TypeMap>) {
-        let table = self.tables
+        let table = self
+            .tables
             .iter_mut()
             .find(|(entry_name, _)| entry_name == &name)
             .map(|(_, resource)| resource.deref_mut())

--- a/src/global/types.rs
+++ b/src/global/types.rs
@@ -117,11 +117,12 @@ impl<'a> ResourcesGuard<'a> {
             .unwrap()
     }
 
-    pub fn write_table(&mut self, name: &str) -> &mut Table {
-        self.tables
+    pub fn write_table(&mut self, name: &str) -> (&mut Table, &Resource<'a, TypeMap>) {
+        let table = self.tables
             .iter_mut()
             .find(|(entry_name, _)| entry_name == &name)
             .map(|(_, resource)| resource.deref_mut())
-            .unwrap()
+            .unwrap();
+        (table, &self.types)
     }
 }

--- a/src/global/types.rs
+++ b/src/global/types.rs
@@ -110,7 +110,7 @@ impl<'a, T> Deref for Resource<'a, T> {
 impl<'a, T> DerefMut for Resource<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            Resource::Read(_) => panic!("Tried to get write access to read-only table resources"),
+            Resource::Read(_) => panic!("Tried to get write access to a read-only resource"),
             Resource::Write(guard) => guard.deref_mut(),
         }
     }

--- a/src/global/types.rs
+++ b/src/global/types.rs
@@ -16,7 +16,10 @@ pub struct TableRequest {
 }
 
 pub enum Request {
-    AcquireResources(Vec<TableRequest>),
+    AcquireResources {
+        table_reqs: Vec<TableRequest>,
+        type_map_perms: RW,
+    },
     CreateTable(String, Table),
 }
 
@@ -29,12 +32,13 @@ pub enum Response {
 
 pub struct Resources {
     dirty: bool,
-    types: Arc<RwLock<TypeMap>>,
+    type_map_perms: RW,
+    type_map: Arc<RwLock<TypeMap>>,
     tables: Vec<(RW, String, Arc<RwLock<Table>>)>,
 }
 
 pub struct ResourcesGuard<'a> {
-    pub types: Resource<'a, TypeMap>,
+    pub type_map: Resource<'a, TypeMap>,
     pub tables: Vec<(&'a str, Resource<'a, Table>)>,
 }
 
@@ -45,12 +49,14 @@ pub enum Resource<'a, T> {
 
 impl Resources {
     pub(super) fn new(
-        types: Arc<RwLock<TypeMap>>,
+        type_map: Arc<RwLock<TypeMap>>,
+        type_map_perms: RW,
         tables: Vec<(RW, String, Arc<RwLock<Table>>)>,
     ) -> Self {
         Self {
             dirty: false,
-            types,
+            type_map,
+            type_map_perms,
             tables,
         }
     }
@@ -66,15 +72,20 @@ impl Resources {
         assert_eq!(self.dirty, false);
         self.dirty = true;
 
+        let pmsg = "Lock is poisoned";
+
         ResourcesGuard {
-            types: Resource::Read(self.types.read().expect("Lock is poisoned")),
+            type_map: match self.type_map_perms {
+                    RW::Read => Resource::Read(self.type_map.read().expect(pmsg)),
+                    RW::Write => Resource::Write(self.type_map.write().expect(pmsg)),
+                },
             tables: self
                 .tables
                 .iter()
                 .map(|(rw, name, lock)| {
                     let resource = match rw {
-                        RW::Read => Resource::Read(lock.read().expect("Lock is poisoned")),
-                        RW::Write => Resource::Write(lock.write().expect("Lock is poisoned")),
+                        RW::Read => Resource::Read(lock.read().expect(pmsg)),
+                        RW::Write => Resource::Write(lock.write().expect(pmsg)),
                     };
 
                     (name.as_str(), resource)
@@ -123,6 +134,6 @@ impl<'a> ResourcesGuard<'a> {
             .find(|(entry_name, _)| entry_name == &name)
             .map(|(_, resource)| resource.deref_mut())
             .unwrap();
-        (table, &self.types)
+        (table, &self.type_map)
     }
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -129,7 +129,7 @@ WhereClause: WhereClause = {
 
 CreateTable: CreateTable = {
     CREATE TABLE <table:Ident>
-        <columns:("(" <Comma<Ident>> ")")>
+        <columns:("(" <Comma<(Ident Ident)>> ")")>
     => CreateTable {
         table,
         columns,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,10 +38,9 @@ fn execute_query(input: &str) -> String {
     };
 
     // 2. determine resources
-    let resource_request = pre_typechecker::get_table_permissions(&ast);
+    let request = pre_typechecker::get_resource_request(&ast);
 
     // 3. acquire resources
-    let request = Request::AcquireResources(resource_request);
     let response = send_request(request);
     let mut resources = match response {
         Response::AcquiredResources(resources) => resources,
@@ -56,9 +55,11 @@ fn execute_query(input: &str) -> String {
         Err(e) => return format!("{:#?}\n", e),
     }
 
-    // 5. TODO: Maybe convert ast to some internal representation of a query (See EXPLAIN in postgres/mysql)
+    // TODO:
+    // 5. Maybe convert ast to some internal representation of a query
+    // (See EXPLAIN in postgres/mysql)
 
-    // 6. TODO: Execute query
+    // 6. Execute query
     executor::execute_query(ast, resources)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod table;
 mod typechecker;
 mod types;
 mod api;
+mod executor;
 
 use api::tcp_api::tcp_api;
 use std::error::Error;
@@ -47,10 +48,10 @@ fn execute_query(input: &str) -> String {
         Response::NoSuchTable(name) => return format!("No such table: {}\n", name),
         _ => unreachable!("Invalid reponse from global::send_request"),
     };
-    let guard = resources.take();
+    let resources = resources.take();
 
     // 4. typecheck
-    match typechecker::check_stmt(&ast, &guard) {
+    match typechecker::check_stmt(&ast, &resources) {
         Ok(()) => {},
         Err(e) => return format!("{:#?}\n", e),
     }
@@ -58,8 +59,7 @@ fn execute_query(input: &str) -> String {
     // 5. TODO: Maybe convert ast to some internal representation of a query (See EXPLAIN in postgres/mysql)
 
     // 6. TODO: Execute query
-
-    return String::from("Not implemented");
+    executor::execute_query(ast, resources)
 }
 
 fn echo_ast(input: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate lazy_static;
 
 mod api;
 mod ast;
+mod executor;
 mod global;
 mod grammar;
 mod pattern;
@@ -15,11 +16,10 @@ mod pre_typechecker;
 mod table;
 mod typechecker;
 mod types;
-mod executor;
 
+use crate::ast::Stmt;
 use api::tcp_api::tcp_api;
 use std::error::Error;
-use crate::ast::Stmt;
 
 #[tokio::main]
 async fn main() -> Result<!, Box<dyn Error>> {
@@ -28,8 +28,8 @@ async fn main() -> Result<!, Box<dyn Error>> {
 
 fn execute_query(input: &str) -> String {
     // 1. parse
-    use crate::grammar::StmtParser;
     use crate::global::*;
+    use crate::grammar::StmtParser;
 
     let result: Result<Stmt, _> = StmtParser::new().parse(&input);
     let ast = match result {
@@ -51,7 +51,7 @@ fn execute_query(input: &str) -> String {
 
     // 4. typecheck
     match typechecker::check_stmt(&ast, &resources) {
-        Ok(()) => {},
+        Ok(()) => {}
         Err(e) => return format!("{:#?}\n", e),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,48 @@ mod api;
 
 use api::tcp_api::tcp_api;
 use std::error::Error;
+use crate::ast::Stmt;
 
 #[tokio::main]
 async fn main() -> Result<!, Box<dyn Error>> {
-    tcp_api(echo_ast, "127.0.0.1:5432".to_string()).await
+    tcp_api(execute_query, "127.0.0.1:5432".to_string()).await
+}
+
+fn execute_query(input: &str) -> String {
+    // 1. parse
+    use crate::grammar::StmtParser;
+    use crate::global::*;
+
+    let result: Result<Stmt, _> = StmtParser::new().parse(&input);
+    let ast = match result {
+        Ok(ast) => ast,
+        Err(e) => return format!("{:#?}\n", e),
+    };
+
+    // 2. determine resources
+    let resource_request = pre_typechecker::get_table_permissions(&ast);
+
+    // 3. acquire resources
+    let request = Request::AcquireResources(resource_request);
+    let response = send_request(request);
+    let mut resources = match response {
+        Response::AcquiredResources(resources) => resources,
+        Response::NoSuchTable(name) => return format!("No such table: {}\n", name),
+        _ => unreachable!("Invalid reponse from global::send_request"),
+    };
+    let guard = resources.take();
+
+    // 4. typecheck
+    match typechecker::check_stmt(&ast, &guard) {
+        Ok(()) => {},
+        Err(e) => return format!("{:#?}\n", e),
+    }
+
+    // 5. TODO: Maybe convert ast to some internal representation of a query (See EXPLAIN in postgres/mysql)
+
+    // 6. TODO: Execute query
+
+    return String::from("Not implemented");
 }
 
 fn echo_ast(input: &str) -> String {

--- a/src/pre_typechecker.rs
+++ b/src/pre_typechecker.rs
@@ -4,14 +4,14 @@ use crate::global::{Request, TableRequest, RW};
 pub fn get_resource_request(stmt: &Stmt) -> Request {
     Request::AcquireResources {
         table_reqs: get_table_resource_requests(stmt),
-        type_map_perms: RW::Read,
+        type_map_perms: get_type_map_resource_perm(stmt),
     }
 }
 
 fn get_type_map_resource_perm(stmt: &Stmt) -> RW {
     match stmt {
         Stmt::CreateType(_) => RW::Write,
-        _ => RW::Write,
+        _ => RW::Read,
     }
 }
 

--- a/src/pre_typechecker.rs
+++ b/src/pre_typechecker.rs
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use crate::global::{TableRequest, RW, Request};
+use crate::global::{Request, TableRequest, RW};
 
 pub fn get_resource_request(stmt: &Stmt) -> Request {
     let mut type_map_perms = RW::Read;
@@ -21,8 +21,8 @@ pub fn get_resource_request(stmt: &Stmt) -> Request {
         Stmt::CreateType(_) => {
             type_map_perms = RW::Write;
             vec![]
-        },
-        Stmt::CreateTable(_)=> vec![],
+        }
+        Stmt::CreateTable(_) => vec![],
     };
 
     Request::AcquireResources {

--- a/src/table.rs
+++ b/src/table.rs
@@ -3,7 +3,7 @@ use crate::types::{EnumTag, Type, TypeId, TypeMap, Value};
 use bincode::deserialize;
 use std::cmp::{Ord, Ordering, PartialOrd};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Schema {
     pub columns: Vec<(String, TypeId)>,
 }
@@ -15,6 +15,7 @@ pub struct Column {
 }
 
 // Table defines
+#[derive(Debug)]
 pub struct Table {
     schema: Schema,
     data: Vec<u8>,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -386,12 +386,12 @@ mod tests {
 
     #[test]
     fn type_check_exprs() {
-        let (_ids, types) = create_type_map();
-        let types = Arc::new(RwLock::new(types));
+        let (_ids, type_map) = create_type_map();
+        let type_map = Arc::new(RwLock::new(type_map));
 
         let dummy_ctx = Context {
             globals: &ResourcesGuard {
-                types: Resource::Read(types.read().unwrap()),
+                type_map: Resource::Read(type_map.read().unwrap()),
                 tables: vec![],
             },
             locals: vec![],

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -191,9 +191,18 @@ fn check_update(update: &Update, ctx: &mut Context) -> Result<(), TypeError> {
 }
 
 fn check_create_table(create_table: &CreateTable, ctx: &mut Context) -> Result<(), TypeError> {
-    for column in &create_table.columns {
-        if ctx.globals.types.get(column).is_none() {
-            return Err(TypeError::Undefined(column.clone()));
+    let columns = &create_table.columns;
+    for (_, column_type) in columns {
+        if ctx.globals.types.get(column_type).is_none() {
+            return Err(TypeError::Undefined(column_type.clone()));
+        }
+    }
+
+    for i in 0..columns.len() {
+        for j in 0..i {
+            if columns[i] == columns[j] {
+                return Err(TypeError::AlreadyDefined);
+            }
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -66,6 +66,10 @@ impl TypeMap {
         &self.types
     }
 
+    pub fn identifiers(&self) -> &HashMap<String, TypeId> {
+        &self.identifiers
+    }
+
     pub fn constructors_of(&self, name: &str) -> Option<&Vec<TypeId>> {
         self.constructors.get(name)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,12 +26,18 @@ impl Index<&TypeId> for TypeMap {
 
 impl TypeMap {
     pub fn new() -> Self {
-        TypeMap {
+        let mut map = TypeMap {
             types: HashMap::new(),
             identifiers: HashMap::new(),
             constructors: HashMap::new(),
             next_id: 1,
-        }
+        };
+
+        // TODO: better handling of primitives
+        map.insert("Integer", Type::Integer);
+        map.insert("Double", Type::Double);
+        map.insert("Bool", Type::Bool);
+        map
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
Implements:
- `CREATE TYPE VARIANT`
- `CREATE TABLE`
- `INSERT INTO`*
  *only supports Value-expressions for now.

Barring ~some~ a lot of refactoring, optimization, and cleaning up the output formatting, the features listed above _should_ be functioning.