### PR TITLE
Executor gets a Writer instead of returning a string

### DIFF
--- a/src/api/tcp_api.rs
+++ b/src/api/tcp_api.rs
@@ -1,15 +1,44 @@
 use std::error::Error;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
+use crate::execute_query;
+use std::io::{self, Write, BufWriter};
+use futures::executor::block_on;
 
-pub async fn tcp_api(func: fn(&str) -> String, address: String) -> Result<!, Box<dyn Error>> {
+type W = dyn Send + AsyncWrite;
+
+struct BlockWriter<W: AsyncWrite + Unpin> {
+    writer: W,
+}
+
+impl<W: AsyncWrite + Unpin> BlockWriter<W> {
+    pub fn new(writer: W) -> Self {
+        BlockWriter {
+            writer,
+        }
+    }
+}
+
+impl<W: AsyncWrite + Unpin> Write for BlockWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        block_on(self.writer.write(buf))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        block_on(self.writer.flush())
+    }
+}
+
+pub async fn tcp_api(address: String) -> Result<!, Box<dyn Error>>
+{
     let mut listener = TcpListener::bind(address).await?;
 
     loop {
         match listener.accept().await {
             Ok((mut socket, _)) => {
                 tokio::spawn(async move {
-                    let (reader, mut writer) = socket.split();
+                    let (reader, writer) = socket.split();
+                    let mut writer = BufWriter::new(BlockWriter::new(writer));
                     let mut buf = vec![];
                     let mut rest = String::new();
                     let mut reader: BufReader<_> = BufReader::new(reader);
@@ -20,18 +49,11 @@ pub async fn tcp_api(func: fn(&str) -> String, address: String) -> Result<!, Box
                         let input = std::str::from_utf8(&buf[..n]).expect("Not valid utf-8");
 
                         rest.push_str(input);
-                        let (result, rest2) = conga(func, rest);
-                        rest = rest2;
+                        rest = conga(execute_query, input, &mut writer);
+                        writer.flush().expect("Flushing writer failed");
 
                         // TODO: fix for unicode
                         buf.drain(..n);
-                        match result {
-                            Some(ret) => {
-                                writer.write_all(ret.as_bytes()).await.unwrap();
-                                writer.flush().await.unwrap();
-                            }
-                            None => (),
-                        }
                     }
                 });
             }
@@ -41,9 +63,9 @@ pub async fn tcp_api(func: fn(&str) -> String, address: String) -> Result<!, Box
 }
 
 // CONGA FIX EVERYTHING
-fn conga(func: fn(&str) -> String, stmt: String) -> (Option<String>, String) {
+fn conga(func: fn(&str, &mut dyn Write) -> Result<(), Box<dyn Error>>, stmt: &str, w: &mut dyn Write) -> String
+{
     let mut in_string = false;
-    let mut result = vec![];
     let mut lasti = 0;
     let chars = stmt.chars().enumerate();
 
@@ -55,49 +77,46 @@ fn conga(func: fn(&str) -> String, stmt: String) -> (Option<String>, String) {
 
         if ch == ';' && !in_string {
             let q = &stmt[lasti..=i];
-            result.push(func(q));
+
+            func(q, w).expect("Query errored");
             lasti = i + 1;
         }
     }
 
-    let mut rest = String::new();
-    let mut ret = None;
-
     if lasti != (stmt.len() - 1) {
-        rest = String::from(&stmt[lasti..stmt.len()]);
+        String::from(&stmt[lasti..stmt.len()])
+    } else {
+        String::new()
     }
-
-    if !result.is_empty() {
-        ret = Some(result.join("\n"));
-    }
-
-    (ret, rest)
 }
 
 #[cfg(test)]
 pub mod tests {
 
     use super::conga;
+    use std::io::Write;
+    use std::error::Error;
 
     #[test]
     pub fn test_conga() {
         let s1 = "SELECT dsdasd FROM dadasd".to_string();
         let s2 = "SELECT dasdas FROM dasdasd; INSERT dadasd into sdadad;".to_string();
 
-        let (r1, rest1) = conga(always_success, s1.clone());
+        let mut r1: Vec<u8> = vec![];
+        let rest1 = conga(always_success, &s1, &mut r1);
 
-        assert_eq!(r1, None);
+        assert!(r1.is_empty());
         assert_eq!(rest1, s1);
 
-        let (r2, rest2) = conga(always_success, s2.clone());
+        let mut r2: Vec<u8> = vec![];
+        let rest2 = conga(always_success, &s2, &mut r2);
 
-        r2.unwrap();
-
+        assert!(!r2.is_empty());
         assert_eq!(rest2, "");
-
     }
 
-    fn always_success(_: &str) -> String{
-        "Success".to_string()
+    fn always_success(_: &str, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+        w.write_all("Success".as_bytes())?;
+        Ok(())
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -3,8 +3,8 @@ use crate::global::{send_request, Request, ResourcesGuard, Response};
 use crate::pattern::CompiledPattern;
 use crate::table::{Schema, Table};
 use crate::types::{Type, TypeId, Value};
-use std::io::Write;
 use std::error::Error;
+use std::io::Write;
 
 struct Context {
     // TODO
@@ -16,7 +16,11 @@ impl Context {
     }
 }
 
-pub(crate) fn execute_query(ast: Stmt, resources: ResourcesGuard, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+pub(crate) fn execute_query(
+    ast: Stmt,
+    resources: ResourcesGuard,
+    w: &mut dyn Write,
+) -> Result<(), Box<dyn Error>> {
     match ast {
         Stmt::CreateTable(create_table) => execute_create_table(create_table, resources, w),
         Stmt::CreateType(create_type) => execute_create_type(create_type, resources, w),
@@ -26,7 +30,11 @@ pub(crate) fn execute_query(ast: Stmt, resources: ResourcesGuard, w: &mut dyn Wr
     }
 }
 
-fn execute_select(select: Select, resources: ResourcesGuard, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+fn execute_select(
+    select: Select,
+    resources: ResourcesGuard,
+    w: &mut dyn Write,
+) -> Result<(), Box<dyn Error>> {
     match select.from {
         Some(SelectFrom::Table(table_name)) => {
             let table = resources.read_table(&table_name);
@@ -48,7 +56,11 @@ fn execute_select(select: Select, resources: ResourcesGuard, w: &mut dyn Write) 
     Ok(())
 }
 
-fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+fn execute_create_table(
+    create_table: CreateTable,
+    resources: ResourcesGuard,
+    w: &mut dyn Write,
+) -> Result<(), Box<dyn Error>> {
     let columns: Vec<_> = create_table
         .columns
         .into_iter()
@@ -74,7 +86,11 @@ fn execute_create_table(create_table: CreateTable, resources: ResourcesGuard, w:
     Ok(())
 }
 
-fn execute_create_type(create_type: CreateType, mut resources: ResourcesGuard, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+fn execute_create_type(
+    create_type: CreateType,
+    mut resources: ResourcesGuard,
+    w: &mut dyn Write,
+) -> Result<(), Box<dyn Error>> {
     let types = &mut resources.type_map;
 
     match create_type {
@@ -103,7 +119,11 @@ fn execute_create_type(create_type: CreateType, mut resources: ResourcesGuard, w
     Ok(())
 }
 
-fn execute_insert(insert: Insert, mut resources: ResourcesGuard, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+fn execute_insert(
+    insert: Insert,
+    mut resources: ResourcesGuard,
+    w: &mut dyn Write,
+) -> Result<(), Box<dyn Error>> {
     let (table, types) = resources.write_table(&insert.table);
 
     let ctx = Context::empty();

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use std::io::Write;
 
 #[tokio::main]
 async fn main() -> Result<!, Box<dyn Error>> {
-    tcp_api("127.0.0.1:5432".to_string()).await
+    tcp_api(execute_query, "127.0.0.1:5432".to_string()).await
 }
 
 fn execute_query(input: &str, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
The writer is a blocking [std::io::Writer](https://doc.rust-lang.org/std/io/trait.Write.html) since [tokio::io::AsyncWrite](https://docs.rs/tokio/0.2.11/tokio/io/trait.AsyncWrite.html)
requires the future to be Send, which ResourceGuard can't be.

We might want to look into fixing this in the future, but for now
this method should be better than returning `String`s.