### PR TITLE
Refactor database as library & add integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,28 @@ dependencies = [
  "futures",
  "lalrpop",
  "lalrpop-util",
+ "prettydiff",
  "rand 0.7.3",
  "regex",
  "smallvec",
  "tokio",
  "tokio-postgres",
  "tokio-util",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -60,9 +76,9 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -152,6 +168,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +211,21 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+dependencies = [
+ "ansi_term 0.11.0",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "cloudabi"
@@ -278,6 +321,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +377,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "strsim",
+ "strsim 0.9.3",
 ]
 
 [[package]]
@@ -329,6 +394,12 @@ checksum = "8944dc8fa28ce4a38f778bd46bf7d923fe73eed5a439398507246c8e017e6f36"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "fake-simd"
@@ -431,9 +502,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -497,6 +568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +612,12 @@ checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "kernel32-sys"
@@ -866,14 +952,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettydiff"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5240be0c9ea1bc7887819a36264cb9475eb71c58749808e5b989c8c1fdc67acf"
+dependencies = [
+ "ansi_term 0.9.0",
+ "prettytable-rs",
+ "structopt",
+]
+
+[[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+dependencies = [
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -881,6 +992,15 @@ name = "proc-macro-nested"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -893,11 +1013,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.8",
 ]
 
 [[package]]
@@ -1086,6 +1215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1249,12 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "scopeguard"
@@ -1148,9 +1292,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1234,8 +1378,8 @@ checksum = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
 dependencies = [
  "phf_generator",
  "phf_shared 0.7.24",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
  "string_cache_shared",
 ]
 
@@ -1257,9 +1401,37 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "structopt"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+dependencies = [
+ "clap",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+dependencies = [
+ "heck",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
 
 [[package]]
 name = "subtle"
@@ -1269,12 +1441,23 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
  "unicode-xid 0.2.0",
 ]
 
@@ -1287,6 +1470,15 @@ dependencies = [
  "byteorder",
  "dirs",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1328,9 +1520,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1394,6 +1586,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1608,12 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ futures = "0.3.4"
 tokio-postgres = "0.5.2"
 async-trait = "0.1.24"
 
+[dev-dependencies]
+prettydiff = "0.3.1"
+
 [build-dependencies]
 lalrpop = "0.17.2"
 
+[features]
+default = []
+wrapper = []

--- a/src/api/custom.rs
+++ b/src/api/custom.rs
@@ -1,0 +1,13 @@
+use crate::client::{client, State};
+use std::error::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Start an instance of the dbms accepting raw queries through AsyncRead and AsyncWrite.
+pub async fn create_with_writers<W, R>(reader: R, writer: W) -> Result<(), Box<dyn Error>>
+where
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    let state = State::new();
+    client(reader, writer, state).await
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,1 +1,2 @@
+pub mod custom;
 pub mod tcp_api;

--- a/src/api/tcp_api.rs
+++ b/src/api/tcp_api.rs
@@ -1,27 +1,28 @@
-use crate::local::*;
-use regex::Regex;
+use crate::client::client;
 use std::error::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufWriter};
-use tokio::net::{TcpStream, TcpListener};
-use std::net::SocketAddr;
-use crate::execute_query;
+use tokio::net::TcpListener;
+use crate::client::State;
 
-pub async fn tcp_api(address: &str) -> Result<!, Box<dyn Error>> {
-    let state = DbmsState::new();
+/// Start an instance of the dbms which binds itself to a tcp socket
+pub async fn create_tcp_server(address: &str) -> Result<!, Box<dyn Error>> {
+    let state = State::new();
 
     let mut listener = TcpListener::bind(address).await?;
 
     loop {
         match listener.accept().await {
-            Ok((socket, client_address)) => {
+            Ok((mut socket, client_address)) => {
                 println!("new client [{}] connected", client_address);
 
                 // Copy state accessor, not the state itself.
                 let state = state.clone();
 
                 tokio::spawn(async move {
-                    match client(socket, client_address, state).await {
-                        Ok(()) => {}
+                    let (reader, writer) = socket.split();
+                    match client(reader, writer, state).await {
+                        Ok(()) => {
+                            println!("client [{}] socket closed", client_address);
+                        }
                         Err(e) => {
                             println!("client [{}] errored: {}", client_address, e);
                         }
@@ -29,59 +30,6 @@ pub async fn tcp_api(address: &str) -> Result<!, Box<dyn Error>> {
                 });
             }
             Err(e) => println!("error accepting socket; error = {:?}", e),
-        }
-    }
-}
-
-async fn client(mut socket: TcpStream, client_address: SocketAddr, state: DbmsState) -> Result<(), Box<dyn Error>> {
-    let (mut reader, writer) = socket.split();
-    let mut writer = BufWriter::new(writer);
-    let mut buf = vec![];
-
-    // This regex matches the entire string from the start to the first non-quoted semi-colon.
-    // It also properly handles escaped quotes
-    // valid string: SELECT "this is a quote -> \", this is a semicolon -> ;.";
-    let r = Regex::new(r#"^(("((\\.)|[^"])*")|[^";])*;"#).expect("Invalid regex");
-
-    loop {
-        let _n: usize = match reader.read_buf(&mut buf).await? {
-            // No bytes read means EOF was reached
-            0 => {
-                println!("client [{}] socket closed", client_address);
-                return Ok(());
-            }
-            // Read n bytes
-            n => n,
-        };
-
-        // Loop over every statement (every substring ending with a semicolon)
-        // This leaves the remaining un-terminated string in the buf.
-        //   stmt 1         stmt 2           stmt 3   rest
-        // ┍╌╌╌┷╌╌╌┑┍╌╌╌╌╌╌╌╌╌┷╌╌╌╌╌╌╌╌╌╌┑┍╌╌╌╌┷╌╌╌╌┑┍╌┷╌┑
-        // SELECT 1; SELECT "stuff: \" ;";  SELECT 3; SELE
-        loop {
-            // Validate bytes as utf-8 string
-            let input = match std::str::from_utf8(&buf[..]) {
-                Ok(input) => input,
-                Err(e) => {
-                    writer.write_all(format!("Error: {}\n", e).as_bytes()).await?;
-                    writer.flush().await?;
-                    return Err(e.into());
-                }
-            };
-
-
-            // Match string against regex
-            let (input, end) = match r.find(input) {
-                Some(matches) => (matches.as_str(), matches.end()),
-                None => break,
-            };
-
-            execute_query(input, &state, &mut writer).await?;
-            writer.flush().await?;
-
-            // Remove the string of the executed query from the buffer
-            buf.drain(..end);
         }
     }
 }

--- a/src/api/tcp_api.rs
+++ b/src/api/tcp_api.rs
@@ -1,7 +1,7 @@
 use crate::client::client;
+use crate::client::State;
 use std::error::Error;
 use tokio::net::TcpListener;
-use crate::client::State;
 
 /// Start an instance of the dbms which binds itself to a tcp socket
 pub async fn create_tcp_server(address: &str) -> Result<!, Box<dyn Error>> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,69 @@
+use crate::executor::execute_query;
+use crate::local;
+use regex::Regex;
+use std::error::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
+
+#[cfg(not(feature = "wrapper"))]
+pub type State = local::DbmsState;
+
+#[cfg(feature = "wrapper")]
+pub type State = local::PgWrapperState;
+
+pub(crate) async fn client<R, W>(
+    mut reader: R,
+    writer: W,
+    state: State,
+) -> Result<(), Box<dyn Error>>
+where
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    let mut writer = BufWriter::new(writer);
+    let mut buf = vec![];
+
+    // This regex matches the entire string from the start to the first non-quoted semi-colon.
+    // It also properly handles escaped quotes
+    // valid string: SELECT "this is a quote -> \", this is a semicolon -> ;.";
+    let r = Regex::new(r#"^(("((\\.)|[^"])*")|[^";])*;"#).expect("Invalid regex");
+
+    loop {
+        let _n: usize = match reader.read_buf(&mut buf).await? {
+            // No bytes read means EOF was reached
+            0 => return Ok(()),
+            // Read n bytes
+            n => n,
+        };
+
+        // Loop over every statement (every substring ending with a semicolon)
+        // This leaves the remaining un-terminated string in the buf.
+        //   stmt 1         stmt 2           stmt 3   rest
+        // ┍╌╌╌┷╌╌╌┑┍╌╌╌╌╌╌╌╌╌┷╌╌╌╌╌╌╌╌╌╌┑┍╌╌╌╌┷╌╌╌╌┑┍╌┷╌┑
+        // SELECT 1; SELECT "stuff: \" ;";  SELECT 3; SELE
+        loop {
+            // Validate bytes as utf-8 string
+            let input = match std::str::from_utf8(&buf[..]) {
+                Ok(input) => input,
+                Err(e) => {
+                    writer
+                        .write_all(format!("Error: {}\n", e).as_bytes())
+                        .await?;
+                    writer.flush().await?;
+                    return Err(e.into());
+                }
+            };
+
+            // Match string against regex
+            let (input, end) = match r.find(input) {
+                Some(matches) => (matches.as_str(), matches.end()),
+                None => break,
+            };
+
+            execute_query(input, &state, &mut writer).await?;
+            writer.flush().await?;
+
+            // Remove the string of the executed query from the buffer
+            buf.drain(..end);
+        }
+    }
+}

--- a/src/executor/dbms.rs
+++ b/src/executor/dbms.rs
@@ -1,10 +1,10 @@
 use crate::ast::*;
 use crate::local::{DbState, DbmsState, ResourcesGuard};
 use crate::pattern::CompiledPattern;
-use crate::table::{Schema, Table};
-use crate::types::{Type, TypeId, Value};
-use crate::typechecker;
 use crate::pre_typechecker;
+use crate::table::{Schema, Table};
+use crate::typechecker;
+use crate::types::{Type, TypeId, Value};
 use std::error::Error;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "wrapper")]
+mod wrapper;
+
+#[cfg(feature = "wrapper")]
+pub(crate) use wrapper::*;
+
+#[cfg(not(feature = "wrapper"))]
+mod dbms;
+
+#[cfg(not(feature = "wrapper"))]
+pub(crate) use dbms::*;

--- a/src/executor/wrapper.rs
+++ b/src/executor/wrapper.rs
@@ -1,6 +1,6 @@
+use crate::local::PgWrapperState;
 use std::error::Error;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use crate::local::PgWrapperState;
 
 pub async fn execute_query(
     _input: &str,

--- a/src/executor/wrapper.rs
+++ b/src/executor/wrapper.rs
@@ -1,0 +1,12 @@
+use std::error::Error;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use crate::local::PgWrapperState;
+
+pub async fn execute_query(
+    _input: &str,
+    _state: &PgWrapperState,
+    writer: &mut (dyn AsyncWrite + Send + Unpin),
+) -> Result<(), Box<dyn Error>> {
+    writer.write_all(b"not implemented.\n").await?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+#![feature(str_strip)]
+#![feature(never_type)]
+#![feature(box_syntax)]
+#![feature(async_closure)]
+#![allow(dead_code)]
+
+mod api;
+mod ast;
+mod client;
+mod executor;
+mod grammar;
+mod local;
+mod pattern;
+mod pre_typechecker;
+mod table;
+mod typechecker;
+mod types;
+//mod psqlwrapper;
+
+pub use api::custom::create_with_writers;
+pub use api::tcp_api::create_tcp_server;

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -22,4 +22,10 @@ where
     async fn create_table(&self, name: String, table: T) -> Result<(), ()>;
 }
 
+#[derive(Clone)]
 pub struct PgWrapperState {}
+impl PgWrapperState {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,5 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<!, Box<dyn Error>> {
-    #[cfg(features = "wrapper")]
-    unimplemented!();
-
     create_tcp_server("127.0.0.1:5432").await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,94 +1,12 @@
-#![feature(str_strip)]
 #![feature(never_type)]
-#![feature(box_syntax)]
-#![feature(async_closure)]
-#![allow(dead_code)]
 
-mod api;
-mod ast;
-mod executor;
-mod grammar;
-mod local;
-mod pattern;
-mod pre_typechecker;
-mod table;
-mod typechecker;
-mod types;
-//mod psqlwrapper;
-
-use crate::ast::Stmt;
-use crate::local::{DbState, DbmsState};
-use api::tcp_api::tcp_api;
+use algebraicdb::create_tcp_server;
 use std::error::Error;
-use std::io::Write;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 #[tokio::main]
 async fn main() -> Result<!, Box<dyn Error>> {
     #[cfg(features = "wrapper")]
     unimplemented!();
 
-    tcp_api("127.0.0.1:5432").await
-}
-
-#[cfg(features = "wrapper")]
-async fn execute_query(
-    input: &str,
-    w: &mut (dyn AsyncWrite + Send + Unpin),
-) -> Result<(), Box<dyn Error>> {
-    Ok(())
-}
-
-#[cfg(not(features = "wrapper"))]
-async fn execute_query(
-    input: &str,
-    s: &DbmsState,
-    w: &mut (dyn AsyncWrite + Send + Unpin),
-) -> Result<(), Box<dyn Error>> {
-    // 1. parse
-    use crate::grammar::StmtParser;
-
-    let result: Result<Stmt, _> = StmtParser::new().parse(&input);
-    let ast = match result {
-        Ok(ast) => ast,
-        Err(e) => return Ok(w.write_all(format!("{:#?}\n", e).as_bytes()).await?),
-    };
-
-    // 2. determine resources
-    let request = pre_typechecker::get_resource_request(&ast);
-
-    // 3. acquire resources
-    let response = s.acquire_resources(request).await;
-    let mut resources = match response {
-        Ok(resources) => resources,
-        Err(name) => {
-            return Ok(w
-                .write_all(format!("No such table: {}\n", name).as_bytes())
-                .await?)
-        }
-    };
-    let resources = resources.take().await;
-
-    // 4. typecheck
-    match typechecker::check_stmt(&ast, &resources) {
-        Ok(()) => {}
-        Err(e) => return Ok(w.write_all(format!("{:#?}\n", e).as_bytes()).await?),
-    }
-
-    // TODO:
-    // 5. Maybe convert ast to some internal representation of a query
-    // (See EXPLAIN in postgres/mysql)
-
-    // 6. Execute query
-    executor::execute_query(ast, s, resources, w).await
-}
-
-fn echo_ast(input: &str, w: &mut dyn Write) -> Result<(), Box<dyn Error>> {
-    use crate::grammar::StmtParser;
-
-    match StmtParser::new().parse(&input) {
-        Ok(ast) => write!(w, "{:#?}\n", ast)?,
-        Err(e) => write!(w, "{:#?}\n", e)?,
-    }
-    Ok(())
+    create_tcp_server("127.0.0.1:5432").await
 }

--- a/src/psqlwrapper/wrapper.rs
+++ b/src/psqlwrapper/wrapper.rs
@@ -13,6 +13,6 @@ pub async fn setup(types: TypeMap, tables: TableMap) -> Result<Wrapper, Error>{
     let (client, _) =
         tokio_postgres::connect("host=localhost user=postgres", NoTls).await?;
 
-    
+
     Ok(Wrapper{client, types, tables})
 }

--- a/test_queries/1/output
+++ b/test_queries/1/output
@@ -1,9 +1,4 @@
 Type Color created 
-Current types:
- Integer
- Double
- Bool
- Color
 Table created
 13 row(s) inserted
 [true, RGB(255, 0, 0)]

--- a/test_queries/2/output
+++ b/test_queries/2/output
@@ -1,37 +1,7 @@
 Type MaybeInt created 
-Current types:
- MaybeInt
- Integer
- Double
- Bool
- Color
 Type Foo created 
-Current types:
- MaybeInt
- Foo
- Integer
- Double
- Bool
- Color
 Type Boi created 
-Current types:
- Boi
- MaybeInt
- Foo
- Integer
- Double
- Bool
- Color
 Type WeMustGoDeeper created 
-Current types:
- MaybeInt
- Foo
- Double
- Bool
- WeMustGoDeeper
- Boi
- Integer
- Color
 Table created
 Table created
 13 row(s) inserted

--- a/test_queries/3/input
+++ b/test_queries/3/input
@@ -1,0 +1,11 @@
+CREATE TABLE ints(int Integer);
+INSERT INTO ints(int) VALUES (42);
+SELECT int FROM ints;
+
+CREATE TABLE f64s(f64 Double);
+INSERT INTO f64s(f64) VALUES (123.321);
+SELECT f64 FROM f64s;
+
+CREATE TABLE bools(bool Bool);
+INSERT INTO bools(bool) VALUES (true);
+SELECT bool FROM bools;

--- a/test_queries/3/output
+++ b/test_queries/3/output
@@ -1,0 +1,9 @@
+Table created
+1 row(s) inserted
+[42]
+Table created
+1 row(s) inserted
+[123.321]
+Table created
+1 row(s) inserted
+[true]

--- a/test_queries/4/input
+++ b/test_queries/4/input
@@ -1,0 +1,5 @@
+CREATE TABLE ints(int Integer);
+
+INSERT INTO ints(int) VALUES (true), (false);
+INSERT INTO ints(int) VALUES (1.0), (42.42);
+

--- a/test_queries/4/output
+++ b/test_queries/4/output
@@ -1,0 +1,9 @@
+Table created
+InvalidType {
+    expected: 1,
+    actual: 3,
+}
+InvalidType {
+    expected: 1,
+    actual: 2,
+}

--- a/tests/test_example_queries.rs
+++ b/tests/test_example_queries.rs
@@ -1,12 +1,12 @@
 use algebraicdb::create_with_writers;
-use tokio::net::UnixStream;
-use std::net::Shutdown;
-use tokio::io::{AsyncWriteExt, BufReader, AsyncBufReadExt};
-use std::io;
-use tokio::stream::{StreamExt};
-use tokio::fs;
-use prettydiff::text::diff_lines;
 use prettydiff::basic::DiffOp;
+use prettydiff::text::diff_lines;
+use std::io;
+use std::net::Shutdown;
+use tokio::fs;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::stream::StreamExt;
 
 #[tokio::test]
 async fn test_example_queries() {
@@ -22,7 +22,10 @@ async fn test_example_queries() {
             let input = fs::read_to_string(input_path).await.unwrap();
             let output = fs::read_to_string(output_path).await.unwrap();
 
-            run_example_query(input, output).await.unwrap().expect("Invalid query output")
+            run_example_query(input, output)
+                .await
+                .unwrap()
+                .expect("Invalid query output")
         }
     }
 }
@@ -44,9 +47,7 @@ async fn run_example_query(input: String, expected_output: String) -> io::Result
     // Read output lines
     let (reader, _) = our_stream.split();
     let reader = BufReader::new(reader);
-    let output: Vec<String> = reader
-        .lines()
-        .collect::<Result<_, _>>().await?;
+    let output: Vec<String> = reader.lines().collect::<Result<_, _>>().await?;
     let output = output.join("\n");
 
     // Check if output matches the expected
@@ -57,7 +58,10 @@ async fn run_example_query(input: String, expected_output: String) -> io::Result
     }) {
         Ok(Ok(()))
     } else {
-        println!("The following query gave an unexpected output:\n\n{}\n-- END QUERY\n", input);
+        println!(
+            "The following query gave an unexpected output:\n\n{}\n-- END QUERY\n",
+            input
+        );
         diff.prettytable();
         Ok(Err(()))
     }

--- a/tests/test_example_queries.rs
+++ b/tests/test_example_queries.rs
@@ -1,0 +1,64 @@
+use algebraicdb::create_with_writers;
+use tokio::net::UnixStream;
+use std::net::Shutdown;
+use tokio::io::{AsyncWriteExt, BufReader, AsyncBufReadExt};
+use std::io;
+use tokio::stream::{StreamExt};
+use tokio::fs;
+use prettydiff::text::diff_lines;
+use prettydiff::basic::DiffOp;
+
+#[tokio::test]
+async fn test_example_queries() {
+    let mut dir = fs::read_dir("test_queries/").await.unwrap();
+    while let Ok(Some(entry)) = dir.next_entry().await {
+        if entry.file_type().await.unwrap().is_dir() {
+            let mut input_path = entry.path();
+            let mut output_path = input_path.clone();
+
+            input_path.push("input");
+            output_path.push("output");
+
+            let input = fs::read_to_string(input_path).await.unwrap();
+            let output = fs::read_to_string(output_path).await.unwrap();
+
+            run_example_query(input, output).await.unwrap().expect("Invalid query output")
+        }
+    }
+}
+
+async fn run_example_query(input: String, expected_output: String) -> io::Result<Result<(), ()>> {
+    // use unix-pipe for communicating with database
+    let (mut db_stream, mut our_stream) = UnixStream::pair()?;
+
+    // Spawn a database
+    tokio::spawn(async move {
+        let (reader, writer) = db_stream.split();
+        create_with_writers(reader, writer).await.unwrap();
+    });
+
+    // Write query input
+    our_stream.write_all(input.as_bytes()).await?;
+    our_stream.shutdown(Shutdown::Write)?;
+
+    // Read output lines
+    let (reader, _) = our_stream.split();
+    let reader = BufReader::new(reader);
+    let output: Vec<String> = reader
+        .lines()
+        .collect::<Result<_, _>>().await?;
+    let output = output.join("\n");
+
+    // Check if output matches the expected
+    let diff = diff_lines(&expected_output, &output);
+    if diff.diff().iter().all(|i| match i {
+        DiffOp::Equal(_) => true,
+        _ => false,
+    }) {
+        Ok(Ok(()))
+    } else {
+        println!("The following query gave an unexpected output:\n\n{}\n-- END QUERY\n", input);
+        diff.prettytable();
+        Ok(Err(()))
+    }
+}


### PR DESCRIPTION
This PR refactors the database into a library, with main.rs simply calling into the public library functions for starting a database.

This means the dbms can be embedded in other applications, or in tests.

### Changes:
- Split executor into multiple files (`executor::dbms` and `executor::wrapper`)
- Move contents of `main.rs` to `lib.rs` and `executor::{dbms, wrapper}`
- Add functions to lib.rs for spawning a database.
  These functions probably have to be updated when we add persistence. 
- Add test which spawns a database and runs the example queries on it.
- Move tcp_api::client to its own module
- `CREATE TYPE` no longer lists all types. (It was printing them in a random order because hashmaps)
- Made the program compile with the placeholder for pg-wrapper

I think that's everything...