### PR TITLE
Char as a primitive type

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -56,6 +56,7 @@ match {
     r"-?[0-9]+(\.[0-9]+)([eE]-?[0-9]+)?" => FLOAT,
     r"[A-z][A-z0-9_]*" => IDENT,
     r#""[^"]*""# => STR,
+    r#"'.'"# => CHAR,
 }
 
 // Main production
@@ -188,6 +189,7 @@ Namespace: String = {
 }
 
 Value: Value = {
+    Char => Value::Char(<>),
     Integer => Value::Integer(<>),
     Double => Value::Double(<>),
     Bool => Value::Bool(<>),
@@ -258,6 +260,10 @@ Ident: String = {
 
 Str: String = {
     STR => String::from(<>.strip_prefix('"').unwrap().strip_suffix('"').unwrap()),
+}
+
+Char: char = {
+    CHAR => <>.chars().nth(1).unwrap(),
 }
 
 Integer: i32 = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -240,6 +240,7 @@ Ass: Ass = {
 
 pub Pattern: Pattern = {
     "_" => Pattern::Ignore,
+    Char => Pattern::Char(<>),
     Integer => Pattern::Int(<>),
     Bool => Pattern::Bool(<>),
     Double => Pattern::Double(<>),

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -6,6 +6,9 @@ use smallvec::SmallVec;
 
 #[derive(Debug)]
 pub enum Pattern {
+    /// Char literal
+    Char(char),
+
     /// Integer literal
     Int(i32),
 
@@ -47,6 +50,9 @@ impl CompiledPattern {
             bindings: &mut Vec<(usize, TypeId, String)>,
         ) {
             match pattern {
+                Pattern::Char(v) => {
+                    matches.push((byte_index, SmallVec::from_vec(serialize(v).unwrap())))
+                }
                 Pattern::Int(v) => {
                     matches.push((byte_index, SmallVec::from_vec(serialize(v).unwrap())))
                 }

--- a/src/table/cell.rs
+++ b/src/table/cell.rs
@@ -24,7 +24,7 @@ impl<'tb, 'ts> Display for Cell<'tb, 'ts> {
         let t = &self.types[&self.type_id];
         let t_size = t.size_of(self.types);
         match t {
-            Type::Integer | Type::Double | Type::Bool => t
+            Type::Integer | Type::Double | Type::Char | Type::Bool => t
                 .from_bytes(&self.data[..t_size], self.types)
                 .unwrap()
                 .fmt(f),
@@ -72,6 +72,9 @@ impl PartialOrd for Cell<'_, '_> {
         debug_assert_eq!(self.type_id, other.type_id);
 
         match &self.types[&self.type_id] {
+            Type::Char => deserialize::<char>(self.data)
+                .unwrap()
+                .partial_cmp(&deserialize::<char>(other.data).unwrap()),
             Type::Integer => deserialize::<i32>(self.data)
                 .unwrap()
                 .partial_cmp(&deserialize(other.data).unwrap()),

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -491,6 +491,7 @@ where
 
 pub fn type_of_value<'a>(value: &'a Value, types: &TypeMap) -> Result<DuckType<'a>, TypeError> {
     match value {
+        Value::Char(_) => Ok(types.get_base_id(BaseType::Char).into()),
         Value::Integer(_) => Ok(types.get_base_id(BaseType::Integer).into()),
         Value::Double(_) => Ok(types.get_base_id(BaseType::Double).into()),
         Value::Bool(_) => Ok(types.get_base_id(BaseType::Bool).into()),

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -191,6 +191,9 @@ fn check_pattern<T: TTable>(
 ) -> Result<(), TypeError> {
     let type_map = &ctx.globals.type_map;
     match pattern {
+        Pattern::Char(_) => {
+            assert_type_as(type_map.get_base_id(BaseType::Char), type_id, type_map)?;
+        }
         Pattern::Int(_) => {
             assert_type_as(type_map.get_base_id(BaseType::Integer), type_id, type_map)?;
         }

--- a/test_queries/5/output
+++ b/test_queries/5/output
@@ -2,7 +2,7 @@ Type MaybeInt created
 Type MaybeMaybeInt created 
 Table created
 InvalidType {
-    expected: 4,
+    expected: 5,
     actual: 1,
 }
 NotASumType

--- a/test_queries/6/output
+++ b/test_queries/6/output
@@ -17,14 +17,14 @@ InvalidType {
     actual: 3,
 }
 InvalidType {
-    expected: 4,
+    expected: 5,
     actual: 1,
 }
 UnrecognizedToken {
     token: (
         44,
         Token(
-            7,
+            8,
             ")",
         ),
         45,
@@ -37,7 +37,7 @@ UnrecognizedToken {
     token: (
         41,
         Token(
-            1,
+            2,
             "42",
         ),
         43,

--- a/test_queries/7/input
+++ b/test_queries/7/input
@@ -1,0 +1,7 @@
+CREATE TABLE chara (a Char);
+
+INSERT INTO chara (a) VALUES ('a');
+INSERT INTO chara (a) VALUES ('ä');
+INSERT INTO chara (a) VALUES ('😂');
+
+SELECT a FROM chara;

--- a/test_queries/7/input
+++ b/test_queries/7/input
@@ -5,3 +5,4 @@ INSERT INTO chara (a) VALUES ('ä');
 INSERT INTO chara (a) VALUES ('😂');
 
 SELECT a FROM chara;
+SELECT a FROM chara WHERE a: 'a';

--- a/test_queries/7/output
+++ b/test_queries/7/output
@@ -5,3 +5,4 @@ Table created
 [a]
 [ä]
 [😂]
+[a]

--- a/test_queries/7/output
+++ b/test_queries/7/output
@@ -1,0 +1,7 @@
+Table created
+1 row(s) inserted
+1 row(s) inserted
+1 row(s) inserted
+[a]
+[ä]
+[😂]


### PR DESCRIPTION
Adds Char as a primitive type using single quotationmarks

Ex: `INSERT INTO tab (row) VALUES ('😂')`;