### PR TITLE
Fix bug when a where clause depended on another

### DIFF
--- a/algebraicdb/src/executor/dbms/mod.rs
+++ b/algebraicdb/src/executor/dbms/mod.rs
@@ -173,8 +173,8 @@ fn full_table_scan<'a>(table: &'a Table, type_map: &'a TypeMap) -> RowIter<'a> {
         .collect();
 
     RowIter {
-        bindings,
-        matches: Arc::new([]),
+        bindings: Arc::new(bindings),
+        matches: Arc::new(vec![]),
         type_map,
         row: Some(0),
     }


### PR DESCRIPTION
```sql
SELECT a, b, c FROM t WHERE a: Some(b), b: c;
```
^ previously broken